### PR TITLE
Fixed working directory parameter in Install-ChocolateyShortcut

### DIFF
--- a/HelpersInstallChocolateyShortcut.md
+++ b/HelpersInstallChocolateyShortcut.md
@@ -15,7 +15,7 @@ Install-ChocolateyShortcut -shortcutFilePath "<path>" -targetPath "<path>"
 ```powershell
 Install-ChocolateyShortcut -shortcutFilePath "C:\test.lnk" -targetPath "C:\test.exe"
 Install-ChocolateyShortcut -shortcutFilePath "C:\notepad.lnk" `
- -targetPath "C:\Windows\System32\notepad.exe" -workDirectory `
+ -targetPath "C:\Windows\System32\notepad.exe" -workingDirectory `
  "C:\" -arguments "C:\test.txt" -iconLocation "C:\test.ico" `
  -description "This is the description"
 ```


### PR DESCRIPTION
HelpersInstallChocolateyShortcut example used an incorrect "workDirectory" parameter instead of "workingDirectory".