### PR TITLE
Add hazel server hosting software to How-To-Host-Feed.md

### DIFF
--- a/How-To-Host-Feed.md
+++ b/How-To-Host-Feed.md
@@ -111,6 +111,7 @@ If you don't want to host on Windows you have only the following options (from l
 * [TeamCity](https://www.jetbrains.com/teamcity/) - contains built-in simple server
 * [Nexus](https://books.sonatype.com/nexus-book/reference/nuget-nuget_proxy_repositories.html)
 * [Artifactory](http://www.jfrog.com/open-source/) - see [Artifactory NuGet Repositories](http://www.jfrog.com/confluence/display/RTF/NuGet+Repositories) - not in the free version
+* [Hazel](https://github.com/MPIB/hazel) - a simple server
 
 
 **Note:** NuGet.Java.Server, TeamCity and JNuGet are about the same in terms of sophistication (they are ordered alphabetically).


### PR DESCRIPTION
Hey there chocolatey team,
the organisation I am working and developing for - the Max-Planck Institute for Human Development - just released our own In-House Chocolatey Gallery Software `Hazel` to the public. It would be nice, if you may add it to your list of alternative hosting solutions.

I have not compared Hazel to Nuget.Java.Server, TeamCity or JNuGet, so I do not know, if the Note below may need to be updated to reflect this new addition.

Thanks!