### PR TITLE
(GH-33) Instructions for installing specific version are incorrect

### DIFF
--- a/DevelopmentEnvironmentSetup.md
+++ b/DevelopmentEnvironmentSetup.md
@@ -60,7 +60,7 @@ cinst nuget.commandline
 
 if (Install-NeededFor 'ruby / ruby devkit') {
   cinst ruby.devkit
-  cinst ruby -version 1.9.3.54500
+  cinst ruby --version 1.9.3.54500
 }
 
 # perform ruby updates and get gems

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1076,7 +1076,7 @@ FEATURES:
 
 BUG FIXES:
 
- * Reinstalls an existing package if -version is passed (first surfaced in 0.9.8.7 w/NuGet 1.5) - [#9](https://github.com/chocolatey/chocolatey/issues/9)
+ * Reinstalls an existing package if --version is passed (first surfaced in 0.9.8.7 w/NuGet 1.5) - [#9](https://github.com/chocolatey/chocolatey/issues/9)
 
 ## 0.9.8.8 (September 10, 2011)
 
@@ -1247,7 +1247,7 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 
- * You can now pass -source and -version to install command.
+ * You can now pass -source and --version to install command.
 
 ## 0.9.2 (April 4, 2011)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1076,7 +1076,7 @@ FEATURES:
 
 BUG FIXES:
 
- * Reinstalls an existing package if --version is passed (first surfaced in 0.9.8.7 w/NuGet 1.5) - [#9](https://github.com/chocolatey/chocolatey/issues/9)
+ * Reinstalls an existing package if -version (0.9.8.7+) or --version (>=0.9.9.0) is passed (first surfaced in 0.9.8.7 w/NuGet 1.5) - [#9](https://github.com/chocolatey/chocolatey/issues/9)
 
 ## 0.9.8.8 (September 10, 2011)
 
@@ -1247,7 +1247,7 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 
- * You can now pass -source and --version to install command.
+ * You can now pass -source and -version (<0.9.9.0) or --version (>=0.9.9.0) to install command.
 
 ## 0.9.2 (April 4, 2011)
 


### PR DESCRIPTION
usage of `-version` produces warning lines in choco. `--version` is the correct parameter name
Fixes #33