### PR TITLE
Ketarin and Sourceforge

### DIFF
--- a/AutomaticPackages.md
+++ b/AutomaticPackages.md
@@ -152,8 +152,6 @@ Try this first:
 * In advanced settings, ensure the user agent is `chocolatey command line`. This will allow ketarin to behave similarly to how Chocolatey does.
 ![Ketarin Job Advanced Settings](https://cloud.githubusercontent.com/assets/63502/7350038/b1928aaa-ecc2-11e4-8abe-af9e7c65c82a.png)
 
-If you want to make an automatic package that downloads files hosted on SourceForge, it gets a bit tricky. Ketarin does not directly support download links from SourceForge in the format `http://sourceforge.net/projects/…/download`, because these download links automatically redirect to a mirror (e.&nbsp;g. `http://heanet.dl.sourceforge.net/project/…`). Ketarin does not support these kind of automatic redirections, but Chocolatey does.
-
 It isn’t uncommon that certain SorceForge mirrors go offline or are extremely slow because of overload. Thus it is not recommended to use direct mirror links (e.&nbsp;g. `http://heanet.dl.sourceforge.net/project/…`) in your `chocolateyInstall.ps1` file, because this will frequently break your package and makes it unreliable.
 To avoid this, use the following convention for files hosted on SourceForge:
 * Don’t use `{{DownloadUrl}}` and `{{DownloadUrlx64}}` in your `chocolateyInstall.ps1` file, but use this instead (example of the app nomacs):
@@ -161,4 +159,3 @@ To avoid this, use the following convention for files hosted on SourceForge:
 and
 `$url64 = 'http://sourceforge.net/projects/nomacs/files/nomacs-{{PackageVersion}}/nomacs-setup-{{PackageVersion}}-x64.exe/download'`
 For other applications obviously you have to use the actual application/file names. Important is that you use `{{PackageVersion}}` and don’t use any direct links which include SourceForge mirrors.
-* In Ketarin there’s no other possibility than using the direct link to a file with an included mirror (e.&nbsp;g. `http://garr.dl.sourceforge.net/project/nomacs/nomacs-{version}/nomacs-setup-{version}-x86.exe`). Unfortunately then Ketarin will occasionally fail to download this file and you will have to manually replace the mirror with a working one to get your automatic package updated. Any clue to fix this issue will be appreciated.


### PR DESCRIPTION
Ketarin 1.8.7.0 binary or either compiled from
https://cdburnerxp.se/downloads/sourcecode/Ketarin.tar.gz
http://scm.flyspray.org/repos/ketarin/
https://github.com/svn2github/ketarin
support sf urls
```sh
http(s)://sourceforge.net/projects/.../files/latest/download
http(s)://downloads.sourceforge.net/projects/.../...
http(s)://prdownloads.sourceforge.net/projects/.../...
```
isn't it?