### PR TITLE
Fix docs typo (minor)

### DIFF
--- a/How-To-Deprecate-A-Chocolatey-Package.md
+++ b/How-To-Deprecate-A-Chocolatey-Package.md
@@ -4,7 +4,7 @@ From time to time, a previously approved Chocolatey Package needs to be deprecat
 * It was created in error.
 * It has been superseded by another package.
 * It is an older package that no longer follows the [Package Guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages).
-* It's package id has been changed to something that better fits with the [package naming guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package).
+* Its package id has been changed to something that better fits with the [package naming guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package).
 
 All versions of this package could simply be unlisted from chocolatey.org, meaning that they could no longer be installed, however, this solution is not ideal.  Any user who previously installed this package, and added it as part of an installation script, would get an error the next time that they tried to install it, and this is far from ideal.
 


### PR DESCRIPTION
Its not It's.
In the right repo this time, thanks!
Supercedes https://github.com/chocolatey/chocolatey.org/pull/462