### PR TITLE
Use choco new testpackage as definitive source of nuspec options

### DIFF
--- a/CreatePackages.md
+++ b/CreatePackages.md
@@ -81,7 +81,7 @@ The main release of a product versions are usually sufficient. If there are also
 ## Okay, how do I create packages?
 There are three main elements to a Chocolatey package. Only the nuspec is required (#1 below).
 
-1. [Nuspec](https://github.com/chocolatey/chocolateytemplates/blob/master/_templates/chocolatey/__NAME__.nuspec) - [Nuspec Reference](http://docs.nuget.org/docs/reference/nuspec-reference)
+1. [Nuspec](CreatePackages#nuspec)
 1. [[chocolateyInstall.ps1|ChocolateyInstallPS1]] - check out the [[helper reference|HelpersReference]]
 1. any application files to include (it is highly suggested that you are the author in this case or you have the right to [[distribute files|Legal]]). EXE files in the package/downloaded to package folder from chocolateyInstall.ps1 will get a link to the command line.
 1. chocolateyUninstall.ps1, for uninstalling your package. See [[helper reference|HelpersReference]] for functions available in your script.
@@ -113,13 +113,13 @@ chocolateyUninstall.ps1                        |         |         | Yes
 
 The chocolateyBeforeModify.ps1 script will only be executed if using choco version 0.9.10 or later.
 
-## Nuspec?
-
-For reference - [Nuspec Reference](http://docs.nuget.org/docs/reference/nuspec-reference)
+## Nuspec
 
 The `Chocolatey` Windows package manager uses the same infrastructure as [NuGet](http://nuget.org/) , the Visual Studio package manager by Outercurve Foundation (sponsored by Microsoft). Therefore packages are based on the same principles. One of those is a package description (specification) in `xml` format, known as the `Nuspec`.
 
-The `Nuspec` contains basic information such as the version, license, maintainer, and package dependencies.
+The `Nuspec` contains basic information such as the version, license, maintainer, and package dependencies. `Chocolatey` includes additional optional functionality on top of [NuGet's Nuspec format](http://docs.nuget.org/docs/reference/nuspec-reference) - the best way to determine currently supported features is to create a test package, and look at the generated nuspec file.
+
+```choco new testpackage```
 
 **Note:** If your package uses recently introduced functionality, you might want to include `chocolatey` as a dependency with the version being the lowest version that has the introduced functionality. Otherwise the installation could fail for users with an older version of `Chocolatey` installed.
 
@@ -132,7 +132,7 @@ You can indicate the `Chocolatey` dependency like any other dependency. E.g.:
 
 Logically, the version is based on the lowest compatible version. But if you don't know and used a lot of sorcery in your package, depend on the version of `Chocolatey` that you succesfully tested your package on.
 
-**See also:** [Nuget Version Reference](http://docs.nuget.org/docs/reference/versioning)
+**See also:** [NuGet Version Reference](http://docs.nuget.org/docs/reference/versioning)
 
 ## But for real, how do I create a package?
 

--- a/CreatePackagesQuickStart.md
+++ b/CreatePackagesQuickStart.md
@@ -9,7 +9,7 @@ Here's a TL;DR quick start version of the package creating tutorial. Follow thes
 * You have Chocolatey installed.
 * You've read [[What are Chocolatey Packages?|GettingStarted#what-are-chocolatey-packages]] first.
 * You know how a package works
-  * A package contains a `nuspec` file. This defines the package. ([Docs](http://docs.nuget.org/docs/reference/nuspec-reference)) ([Example](https://github.com/chocolatey/chocolateytemplates/blob/master/_templates/chocolatey/__NAME__.nuspec))
+  * A package contains a `nuspec` file. This defines the package. ([[Docs|CreatePackages#nuspec]])
   * A package may contain embedded software.
   * A package may contain an installation script. This can be [[very simple|CreatePackagesQuickStart#examples]].
 
@@ -23,7 +23,7 @@ Here's a TL;DR quick start version of the package creating tutorial. Follow thes
    * Edit the `package-name.nuspec` configuration file.
    * Edit the `./tools/chocolateyInstall.ps1` install script.
      * Make sure you figure out the installer's silent mode. Use [Universal Silent Switch Finder](http://unattended.sourceforge.net/installers.php), which is available as a Choco package: `choco install ussf`
-   * You __must__ save your files with _UTF-8_ character encoding without BOM. ([Details](https://github.com/chocolatey/choco/wiki/CreatePackages#character-encoding))
+   * You __must__ save your files with _UTF-8_ character encoding without BOM. ([Details](CreatePackages#character-encoding))
 * **Build the package**
    * Still in package directory
    * `choco pack`


### PR DESCRIPTION
Updates docs to make `choco new testpackage` the definitive source of NuGet functionality. Following on from a gitter convo: https://gitter.im/chocolatey/choco?at=5863dec9c02c1a3959c04fff

I haven't made any issue or anything to update/improve https://github.com/chocolatey/chocolateytemplates - which were previously linked as examples, but I removed the example as I thought `choco new` is probable a better source. Will leave that one with you guys - thanks! :-)