### PR TITLE
Remove mentioning of ProGet Chocolatey package

### DIFF
--- a/How-To-Host-Feed.md
+++ b/How-To-Host-Feed.md
@@ -8,7 +8,7 @@ There are three types of package repositories, [folder/unc share](#local-folder-
 
 **Alternative Hosting Options (that require less work/maintenance):**
 * [MyGet](https://www.myget.org/) - MyGet has free public and paid for public/private cloud-hosting options if you don't want to handle all of the pain of setup and administration. MyGet offers some stellar options like multi-feed aggregation, mirroring, and source package build services!
-* [ProGet](http://inedo.com/proget/overview) - ProGet gives you a ready to go On-Premise option ([installable with Chocolatey!](https://chocolatey.org/packages/proget)).
+* [ProGet](http://inedo.com/proget/overview) - ProGet gives you a ready to go On-Premise option.
 * [Artifactory](http://www.jfrog.com/open-source/) - see [Artifactory NuGet Repositories](http://www.jfrog.com/confluence/display/RTF/NuGet+Repositories) - not in the free version
 * [TeamCity](https://www.jetbrains.com/teamcity/) has built-in Simple Server
 * [Nexus](https://books.sonatype.com/nexus-book/reference/nuget-nuget_proxy_repositories.html) - Sonatype Nexus has a built-in simple server


### PR DESCRIPTION
Remove mentioning of ProGet being able to be installed using Chocolatey, since that package is broken, Inedo admitted that they haven't touched it since ages and show no interested in fixing it (instead people should build their own scripts)