### PR TITLE
Fix #75 Variable reference is not valid

### DIFF
--- a/HelpersGetPackageParameters.md
+++ b/HelpersGetPackageParameters.md
@@ -77,8 +77,9 @@ if (!$pp['LICENSE']) { $pp['LICENSE'] = '1234' }
 ~~~powershell
 
 $pp = Get-PackageParameters
+if (!$pp['UserName']) { $pp['UserName'] = "$env:UserName" }
 # Requires 0.10.8 for Read-Host -AsSecureString
-if (!$pp['Password']) { $pp['Password'] = Read-Host "Enter password for $userName:" -AsSecureString}
+if (!$pp['Password']) { $pp['Password'] = Read-Host "Enter password for $($pp['UserName']):" -AsSecureString}
 # fail the install/upgrade if not value is not determined
 if (!$pp['Password']) { throw "Package needs Password to install, that must be provided in params or in prompt." }
 ~~~

--- a/How-To-Parse-PackageParameters-Argument.md
+++ b/How-To-Parse-PackageParameters-Argument.md
@@ -39,8 +39,9 @@ $pp = Get-PackageParameters
 if (!$pp['LICENSE']) { $pp['LICENSE'] = Read-Host 'License key?' }
 # set a default if not passed
 if (!$pp['LICENSE']) { $pp['LICENSE'] = '1234' }
+if (!$pp['UserName']) { $pp['UserName'] = "$env:UserName" }
 # Requires 0.10.8 for Read-Host -AsSecureString
-if (!$pp['Password']) { $pp['Password'] = Read-Host "Enter password for $userName:" -AsSecureString}
+if (!$pp['Password']) { $pp['Password'] = Read-Host "Enter password for $($pp['UserName']):" -AsSecureString}
 # fail the install/upgrade if not value is not determined
 if (!$pp['Password']) { throw "Package needs parameter 'Password' to install, that must be provided in params or in prompt." }
 


### PR DESCRIPTION
Fix #75 Variable reference is not valid. ':' was not followed by a valid variable name character.