### PR TITLE
Explicitly mention the default location

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -586,8 +586,8 @@ See [[Installing Chocolatey Behind a Proxy Server|Proxy-Settings-for-Chocolatey#
   * Copy/Move over the items from the old lib/bin directory.
   * Delete your old install directory.
 
-**NOTE**: There is one really important consideration when installing Chocolatey to a non-default location - Chocolatey only locks down the permissions to Admins when installed to the default location.
-If you are installing to another location, you will need to handle this yourself.
+**NOTE**: There is one really important consideration when installing Chocolatey to a non-default location: Chocolatey only locks down the permissions to Admins when installed to the default location `%PROGRAMDATA%\Chocolatey`, which means the same thing as `%SystemDrive%\ProgramData\Chocolatey`.
+If you are installing to another location, you will need to handle this yourself, i. e. restrict write access to Admins in case you so desire.
 This is due to alternative locations could have a range of permissions that should not be changed.
 See [[Why does Chocolatey install where it does|DefaultChocolateyInstallReasoning]] and https://github.com/chocolatey/choco/issues/398 for more details.
 


### PR DESCRIPTION
Currently, this section explains how the user’s choice of install location affects the Chocolatey installer in its decision whether to lock down permissions or not.

This PR aims to clarify that explanation in the following ways:

1. State the default location, i. e. `<SYSTEM_DRIVE>:\ProgramData\Chocolatey`; and

2. add an explanation of what _handl\[ing\] \[permissions\] yourself_ is supposed to mean.

Some readers may already know the default location before they get to that section. It might not be their first Choco installation, or they may have seen it being referenced in the PowerShell snippets. That said, I feel that it should not be left to chance whether the reader learns about the default location or not, especially if they wish to do a non-admin install.
