### PR TITLE
Remove outdated release date for Chocolatey Central Console

### DIFF
--- a/FeaturesAgentService.md
+++ b/FeaturesAgentService.md
@@ -185,8 +185,6 @@ This makes for happy users and happy admins as they are able to move quicker tow
 
 ### Chocolatey Central Console
 
-**NOTE:** The console is estimated to be available by end of 2017. All notes here are what we expect, but the standard disclaimer of availability and features apply.
-
 Chocolatey will have a central core console that will allow you to manage your environments. You will need the Chocolatey Agent installed on all machines you wish to manage centrally.
 
 #### Chocolatey Central Console Roadmap


### PR DESCRIPTION
2017 is gone since a while 😉 