### PR TITLE
(GH-102) Fixed typo in markdown link

### DIFF
--- a/ChocolateyFAQs.md
+++ b/ChocolateyFAQs.md
@@ -446,7 +446,7 @@ There is! This is a long video due to slow internet connections, but watch the f
 
 <a id="markdown-i-just-took-over-as-the-primary-maintainer-of-a-package-what-do-i-need-to-do" name="i-just-took-over-as-the-primary-maintainer-of-a-package-what-do-i-need-to-do"></a>
 ### I just took over as the primary maintainer of a package. What do I need to do?
-See [[Package Maintainer Handover|PackageMantainerHandover]]
+See [[Package Maintainer Handover|PackageMaintainerHandover]]
 
 <a id="markdown-what-is-moderation" name="what-is-moderation"></a>
 ### What is moderation?

--- a/CreatePackages.md
+++ b/CreatePackages.md
@@ -42,7 +42,7 @@ can do just about anything you need. Choco has some very handy [[built-in functi
 1. [[Localization|CreatePackages#internationalization-and-localization-of-packages]]
 1. [[Building|CreatePackages#build-your-package]] / [[Testing|CreatePackages#testing-your-package]] / [[Pushing|CreatePackages#push-your-package]]
 1. [[Maintainer magic - automatically updating packaging|AutomaticPackages]]
-1. [[Taking over existing package|PackageMantainerHandover]]
+1. [[Taking over existing package|PackageMaintainerHandover]]
 
 ## Quick Start guide
 
@@ -342,4 +342,4 @@ You can also log into chocolatey.org and upload your package from there (not rec
 Yes - [[Automatic Packaging|AutomaticPackages]]
 
 ## Becoming a primary maintainer of an existing package
-See [[Package Maintainer Handover|PackageMantainerHandover]]
+See [[Package Maintainer Handover|PackageMaintainerHandover]]

--- a/PackageTriageProcess.md
+++ b/PackageTriageProcess.md
@@ -89,4 +89,4 @@ So a package needs fixed or updated. You have reached out to the maintainer or D
 **NOTE**: We don't have non-maintainer uploads in the community feed and we haven't needed them yet.
 
 ### New Maintainers
-Sometimes this results in new maintainers. You can be a maintainer updating the project at a central location that multiple maintainers share. However, if you became maintainer because the package was deemed abandoned, you will want to follow the instructions for a [Package Maintainer Handover/Switch](PackageMantainerHandover).
+Sometimes this results in new maintainers. You can be a maintainer updating the project at a central location that multiple maintainers share. However, if you became maintainer because the package was deemed abandoned, you will want to follow the instructions for a [Package Maintainer Handover/Switch](PackageMaintainerHandover).


### PR DESCRIPTION
The current markdown links to the package maintainer handover page
currently have a missing 'i' in the link.
This PR adds that missing 'i' to all instances.

fixes #102 