### PR TITLE
(GH-126) Update resources section with new blog post

### DIFF
--- a/Resources.md
+++ b/Resources.md
@@ -48,6 +48,7 @@ See [[Infrastructure automation|FeaturesInfrastructureAutomation]]
 
 #### April
 * https://www.gep13.co.uk/blog/new-chocolatey-github-organisations
+* [Build a Chocolatey Package Repository using Azure DevOps Artifacts Feed](https://blog.pauby.com/post/chocolatey-repository-using-azure-devops-artifacts-feed/)
 * https://blog.pauby.com/post/getting-started-with-chocolatey-and-jenkins/ (C4B)
 
 #### January

--- a/Resources.md
+++ b/Resources.md
@@ -49,7 +49,7 @@ See [[Infrastructure automation|FeaturesInfrastructureAutomation]]
 #### April
 * https://www.gep13.co.uk/blog/new-chocolatey-github-organisations
 * [Build a Chocolatey Package Repository using Azure DevOps Artifacts Feed](https://blog.pauby.com/post/chocolatey-repository-using-azure-devops-artifacts-feed/)
-* https://blog.pauby.com/post/getting-started-with-chocolatey-and-jenkins/ (C4B)
+* [Getting Started With Chocolatey 4 Business & Jenkins CI](https://blog.pauby.com/post/getting-started-with-chocolatey-and-jenkins/) (C4B)
 
 #### January
 * https://www.gep13.co.uk/blog/what-are-all-the-chocolatey-repositories-for


### PR DESCRIPTION
* Update the resources section with a new community blog post;
* Add a URL link on the name of a previous blog post (rather than having bare URL showing);