### PR TITLE
(GH-148) Fix invalid walkthrough link

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -9,7 +9,7 @@
 - [Information](#information)
 - [Using Chocolatey](#using-chocolatey)
 - [Packages](#packages)
-- [Walkthroughs / How To Links](#walkthroughs--how-to-links)
+- [Walkthroughs / How To Links](#walkthroughs-how-to-links)
 - [Road Map](#road-map)
   - [Important Reference Links](#important-reference-links)
 - [See It In Action](#see-it-in-action)


### PR DESCRIPTION
Fixes the invalid URL on the Docs home page pointing to walkthrough.

Closes #148 