### PR TITLE
Update links to workshops

### DIFF
--- a/Resources.md
+++ b/Resources.md
@@ -21,7 +21,9 @@ Table of Contents
 
 ## Labs
 
-* https://github.com/ferventcoder/chocolatey-workshop (Packaging Workshop)
+* Chocolatey Workshop - https://github.com/chocolatey/chocolatey-workshop
+* Chocolatey Workshop - Organizational Use - https://github.com/chocolatey/chocolatey-workshop-organizational-use
+* Chocolatey Workshop - Internalizer - https://github.com/chocolatey/chocolatey-workshop-internalizer
 
 ## Translations
 


### PR DESCRIPTION
Updates link to Chocolatey Workshop to current link. Also adds link to Organizational Use and Internalizer workshop.