### PR TITLE
(layout) Update right nav for chocolatey.org

### DIFF
--- a/FeaturesInfrastructureAutomation.md
+++ b/FeaturesInfrastructureAutomation.md
@@ -4,7 +4,7 @@ Chocolatey integrates with several infrastructure automation tools!
 
 With most of these tools, the interface you would interact with Chocolatey would be through the tool or through the interfaces of the tool, like in scripts.
 
-<!--remove {{AT}}section SideColumn { remove-->
+<!--remove <div id="RightNav"> remove-->
 <!-- TOC depthTo:2 -->
 
 - [Summary](#summary)
@@ -21,7 +21,7 @@ With most of these tools, the interface you would interact with Chocolatey would
 - [System Center Configuration Manager](#system-center-configuration-manager)
 
 <!-- /TOC -->
-<!--remove } remove-->
+<!--remove </div> remove-->
 
 ## Summary
 

--- a/Home.md
+++ b/Home.md
@@ -2,7 +2,7 @@
 
 ![Chocolatey Logo](https://cdn.rawgit.com/chocolatey/choco/14a627932c78c8baaba6bef5f749ebfa1957d28d/docs/logo/chocolateyicon.gif "Chocolatey")
 
-<!--remove {{AT}}section SideColumn { remove-->
+<!--remove <div id="RightNav"> remove-->
 <!-- TOC -->
 
 - [What is Chocolatey?](#what-is-chocolatey)
@@ -17,7 +17,7 @@
 - [Who Are We?](#who-are-we)
 
 <!-- /TOC -->
-<!--remove } remove-->
+<!--remove </div> remove-->
 
 ## What is Chocolatey?
 Chocolatey is a software management solution unlike anything else you've ever experienced on Windows. It focuses on simplicity, security, and scalability. You write a software deployment in PowerShell once for any software (not just installers), then you can deploy it everywhere you have Windows with any solution that can manage systems (configuration management, endpoint management, etc) and track and manage updates of that software over time. Manage software on-premise, in the "Cloud", or in [Docker containers](https://github.com/Microsoft/vsts-agent-docker/blob/f870fbf259a803c6a6d902e1c01f631936069d66/windows/servercore/10.0.14393/standard/VS2017/Dockerfile) with Chocolatey.

--- a/How-To-Recompile-Packages.md
+++ b/How-To-Recompile-Packages.md
@@ -1,6 +1,6 @@
 # How To Internalize/Recompile Packages
 
-<!--remove {{AT}}section SideColumn { remove-->
+<!--remove <div id="RightNav"> remove-->
 <!-- TOC -->
 
 - [What is it? Why?](#what-is-it-why)
@@ -9,7 +9,7 @@
 - [How To Internalize/Recompile An Existing Package Manually](#how-to-internalizerecompile-an-existing-package-manually)
 
 <!-- /TOC -->
-<!--remove } remove-->
+<!--remove </div> remove-->
 
 ## What is it? Why?
 Sometimes creating packages from scratch can be an involved process. Not all software installers are created equal (and not all are easily automated either)! Thankfully there is already a tremendous resource you can use to make the process of getting your software all packaged up even smoother.

--- a/Installation.md
+++ b/Installation.md
@@ -1,4 +1,4 @@
-<!--remove {{AT}}section SideColumn { remove-->
+<!--remove <div id="RightNav"> remove-->
 <!-- TOC -->
 
 - [Requirements](#requirements)
@@ -10,7 +10,7 @@
 - [FAQs](#faqs)
 
 <!-- /TOC -->
-<!--remove } remove-->
+<!--remove </div> remove-->
 
 ## Requirements
 * Windows 7+ / Windows Server 2003+

--- a/Presentations.md
+++ b/Presentations.md
@@ -1,11 +1,11 @@
-<!--remove {{AT}}section SideColumn { remove-->
+<!--remove <div id="RightNav"> remove-->
 <!-- TOC -->
 
 * [Presentations](#presentations)
 * [Podcasts](#podcasts)
 
 <!-- /TOC -->
-<!--remove } remove-->
+<!--remove </div> remove-->
 
 ## Presentations
 ### 2017

--- a/Resources.md
+++ b/Resources.md
@@ -1,4 +1,4 @@
-<!--remove {{AT}}section SideColumn { remove-->
+<!--remove <div id="RightNav"> remove-->
 <!-- TOC -->
 
 * [Courses](#courses)
@@ -12,7 +12,7 @@
 * [[Presentations|Presentations]]
 
 <!-- /TOC -->
-<!--remove } remove-->
+<!--remove </div> remove-->
 
 ## Courses
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,7 +1,7 @@
 # Roadmap
 Heading down a sweet road.
 
-<!--remove {{AT}}section SideColumn { remove-->
+<!--remove <div id="RightNav"> remove-->
 <!-- TOC -->
 
 - [Chocolatey](#chocolatey)
@@ -11,7 +11,7 @@ Heading down a sweet road.
 - [Legal](#legal)
 
 <!-- /TOC -->
-<!--remove } remove-->
+<!--remove </div> remove-->
 
 **NOTE:** This is not always going to be updated, one can take a look at the issues list here and in the chocolatey.org repositories.
 


### PR DESCRIPTION
**This PR should be pushed along with https://github.com/chocolatey/chocolatey.org/pull/724**

With the update of using Markdig to convert .md files instead of
Pandoc, a simple change has been made to how the right side navigation
is rendered on chocolatey.org. The look and feel remains the same.