### PR TITLE
(maint) Correct link format

### DIFF
--- a/FeaturesAgentService.md
+++ b/FeaturesAgentService.md
@@ -217,7 +217,7 @@ This makes for happy users and happy admins as they are able to move quicker tow
 
 ### Chocolatey Central Management
 
-Chocolatey has a centralized reporting and ultimately will also support endpoint management through [Chocolatey Central Management (CCM)](FeaturesChocolateyCentralManagement.md). On machines that will take advantage of CCM, you will need the Chocolatey Agent installed and properly configured to manage them centrally.
+Chocolatey has a centralized reporting and ultimately will also support endpoint management through [[Chocolatey Central Management (CCM)|FeaturesChocolateyCentralManagement]]. On machines that will take advantage of CCM, you will need the Chocolatey Agent installed and properly configured to manage them centrally.
 
 ## See It In Action
 


### PR DESCRIPTION
A link was using the incorrect format that is not used anywhere else in the repository. When clicking on the link, it takes you to the raw file, and does not work at all on chocolatey.org.

The format has been corrected to how it used throughout the repository, and now works on choco-wiki and on chocolatey.org.