### PR TITLE
(maint) Fix broken links

### DIFF
--- a/ChocolateyConfiguration.md
+++ b/ChocolateyConfiguration.md
@@ -67,7 +67,7 @@ Config settings are adjusted using `choco config set --name="'<nameFromBelow>'" 
 * `centralManagementCertificateValidationMode` = **'PeerOrChainTrust'** - The certificate mode that is used in communication to Chocolatey Central Management.  Available in business editions v2.0.0+ only.
 
 ### Package Throttle
-* `maximumDownloadRateBitsPerSecond` = **' '** - The maximum download rate in bits per second. '0' or empty means no maximum. A number means that will be the maximum download rate in bps. Defaults to ''. Available in licensed editions v1.10+ only. See https://chocolatey.org/docs/features-download-throttle
+* `maximumDownloadRateBitsPerSecond` = **' '** - The maximum download rate in bits per second. '0' or empty means no maximum. A number means that will be the maximum download rate in bps. Defaults to ''. Available in licensed editions v1.10+ only. See https://chocolatey.org/docs/features-package-throttle
 
 ### Windows Services Installation
 * `serviceInstallsDefaultUserName` = **'ChocolateyLocalAdmin'** - The default user name to use for installing services when one is not specified. Defaults to 'ChocolateyLocalAdmin'. The feature 'useLocalSystemForServiceInstalls' must be set to 'false' to use this field. Available in business editions v1.12.0+ only.

--- a/FeaturesPackageThrottle.md
+++ b/FeaturesPackageThrottle.md
@@ -58,7 +58,7 @@ Global Config Setting:
        bits per second. '0' or empty means no maximum. A number means that will
        be the maximum download rate in bps. Defaults to config setting of '0'.
        Available in [licensed editions](https://chocolatey.org/compare) v1.10+ only. See https://chocolate-
-       y.org/docs/features-download-throttle
+       y.org/docs/features-package-throttle
 ~~~
 
 ## FAQ

--- a/Home.md
+++ b/Home.md
@@ -61,7 +61,7 @@ Whew, that was a mouthful! For a bit more detail into what all of that means and
 * [[Deploy Chocolatey in an Organization|How-To-Setup-Offline-Installation]]
 
 ## Road Map
-Where are [[we|RoadMap]]? Where are we [[going|RoadMap]]?
+Where are [[we|Roadmap]]? Where are we [[going|Roadmap]]?
 
 ### Important Reference Links
 


### PR DESCRIPTION
Two links inside of the documentation have been updated and corrected, as they were broken before on Chocolatey.org.

* /road-map > /roadmap
* /features-package-throttle > /features-download-throttle