### PR TITLE
(doc) Fix missing code delimiter

### DIFF
--- a/CommandsReference.md
+++ b/CommandsReference.md
@@ -99,7 +99,7 @@ based on choco not receiving things you think you are passing to it.
 
  * For consistency, always use `choco`, not `choco.exe`. Never use
    shortcut commands like `cinst` or `cup`.
- * Always have the command as the first argument to `choco. e.g.
+ * Always have the command as the first argument to `choco`. e.g.
    [[`choco install`|Commandsinstall]], where [[`install`|Commandsinstall]] is the command.
  * If there is a subcommand, ensure that is the second argument. e.g.
    `choco source list`, where `source` is the command and [[`list`|Commandslist]] is the


### PR DESCRIPTION
You can see the issue in the second bullet point here:
https://chocolatey.org/docs/commands-reference#scripting-integration-best-practices-style-guide