### PR TITLE
(maint) Fix markdown heading syntax

### DIFF
--- a/DevelopmentEnvironmentSetup.md
+++ b/DevelopmentEnvironmentSetup.md
@@ -1,4 +1,4 @@
-##Set Up A Development Environment Using Chocolatey
+## Set Up A Development Environment Using Chocolatey
 
 How many of you out there are rake fans? Getting developers to look at your source code can sometimes be an issue. Wouldn't it be nice if it was simple for them to get all set up? What about Ruby DevKit? It would be nice, right?
 


### PR DESCRIPTION
Noticed the h2 wasn't rendering properly at the top of the page [here](https://chocolatey.org/docs/development-environment-setup) - so made a quick tweak to fix it 👍 