### PR TITLE
Add ignore dependencies option

### DIFF
--- a/How-To-Setup-Internal-Package-Repository.md
+++ b/How-To-Setup-Internal-Package-Repository.md
@@ -289,7 +289,7 @@ Jenkins requires several PowerShell scripts to automate the processes. Create a 
 
   $pkgs | ForEach-Object {
       Write-Verbose "Downloading package '$($_.name)' to '$tempPath'."
-      choco download $_.name --no-progress --output-directory=$tempPath --source=$TestRepo
+      choco download $_.name --no-progress --output-directory=$tempPath --source=$TestRepo --ignore-dependencies
       if ($LASTEXITCODE -eq 0) {
           $pkgPath = (Get-Item -Path (Join-Path -Path $tempPath -ChildPath '*.nupkg')).FullName
 


### PR DESCRIPTION
@pauby I know that there was some discussion around the addition of this in the PR that @ryanrichter94 created, but I have tested these scripts, and I can confirm that this option is indeed needed for things to work.

Without this in place, the choco push command fails, since it includes all dependent packages.

The script which syncs the test to chocolatey community repository, or which internalizes a new package, already handles the dependencies on a package.  This script, is only for sync between test to prod repos, so it isn't necessary to download dependencies.

Thoughts?