### PR TITLE
(#240, #241) Update terminology and guidelines for Central Management Deployments

### DIFF
--- a/CentralManagement/CentralManagementDeployments.md
+++ b/CentralManagement/CentralManagementDeployments.md
@@ -172,11 +172,10 @@ You may want to configure this only for the first step of a deployment, or for m
 > If the deployment is scheduled with a maintenance window set, the `Machine Contact Timeout` value of the first deployment step is ignored.
 > In this case, the maintenance window defines the contact timeout for the first step.
 
-Depending on your environment and expectations, you can also set the `Execution Timeout` value of a deployment step to `0`.
-This has a similar effect, preventing any deployment step action from being marked as failed or inconclusive until the Chocolatey Agent from that particular machine reports back in.
-If you expect users to be moving devices in and out of your network frequently, you may need to configure the execution timeout value accordingly.
-
+The `Execution Timeout` is the maximum allowed time for the Chocolatey Agent to execute the deployment step task.
 Any positive value for this setting will be respected, and as with `Machine Contact Timeout`, a `0` value is treated as infinite.
+However, if the execution timeout is infinite and a computer goes offline, that deployment step will not complete until that computer checks in again.
+Infinite execution timeouts are **not recommended** for this reason &mdash; deployment steps may end up seemingly stalling for long periods of time and/or require manual intervention to cancel them.
 
 ### What Happens if More Than One Deployment is "Active" at the Same Time?
 
@@ -242,6 +241,14 @@ Catch the recording of the Jun 32rd, 2020 webinar for a full showcase of the Cho
 ---
 
 ## Common Errors and Resolutions
+
+### A deployment step is stalled with infinite execution timeout
+
+The only way to resolve this currently is to cancel the deployment itself, which can be done from the main Deployments list.
+On the right-hand side of the Active Deployments table, click the Actions menu for the corresponding deployment, and select `Cancel`.
+You will be asked to confirm the cancellation.
+
+All remaining steps in the deployment will be cancelled, along with any still running or pending tasks.
 
 ### The updated license file is not being picked up in the website
 

--- a/CentralManagement/CentralManagementDeployments.md
+++ b/CentralManagement/CentralManagementDeployments.md
@@ -163,7 +163,7 @@ This is a switch that is passed to opt out of Chocolatey Self-Service. It's typi
 As of CCM v0.4.0, you are able to configure deployments to tolerate semi-connected environments.
 This effectively allows CCM deployments to simply wait until a machine is connected to the network before it begins a given deployment step.
 
-To configure this, you can set the `Machine Contact Timeout in Minutes` value in the Advanced settings of each individual Deployment Step to `0`.
+To configure this, you can set the `Machine Contact Timeout` value in the Advanced settings of each individual Deployment Step to `0`.
 This value must be positive, or zero (which is treated as infinite).
 You may want to configure this only for the first step of a deployment, or for multiple steps if you expect the target machines to be connected/disconnected over the course of the deployment.
 
@@ -172,7 +172,7 @@ You may want to configure this only for the first step of a deployment, or for m
 > If the deployment is scheduled with a maintenance window set, the `Machine Contact Timeout` value of the first deployment step is ignored.
 > In this case, the maintenance window defines the contact timeout for the first step.
 
-Depending on your environment and expectations, you can also set the `Execution Timeout in Seconds` value of a deployment step to `0`.
+Depending on your environment and expectations, you can also set the `Execution Timeout` value of a deployment step to `0`.
 This has a similar effect, preventing any deployment step action from being marked as failed or inconclusive until the Chocolatey Agent from that particular machine reports back in.
 If you expect users to be moving devices in and out of your network frequently, you may need to configure the execution timeout value accordingly.
 


### PR DESCRIPTION
Fixes #241 - Use consistent terms for Machine Contact Timeout / Execution Timeout
Units for the properties are more of an implementation detail than a description of what it's for, so I went for the unit-less terms for the documentation. 

Fixes #240 - Updated guidelines around execution timeout to make it clear that it's not really recommended, and a section to common errors & resolutions around handling that eventuality if something stalls.